### PR TITLE
Fix de la soustraction

### DIFF
--- a/operators.py
+++ b/operators.py
@@ -32,7 +32,7 @@ def subtract(a,b):
     Returns:
         float: Le résultat de la soustraction
     """
-    return b - a
+    return a - b
 
 def multiply(a,b):
     """


### PR DESCRIPTION
La fonction effectuait toujours la soustraction en prenant l’opérande de droite moins l’opérande de gauche au lieu d’effectuer l’opérande de gauche moins l’opérande de droite. Par conséquent, au lieu de faire b - a, la fonction a été modifiée pour faire a - b.