### PR TITLE
Fix de la multiplication

### DIFF
--- a/operators.py
+++ b/operators.py
@@ -44,7 +44,7 @@ def multiply(a,b):
     Returns:
         float: Le résultat de la multiplication
     """
-    return a ** b
+    return a * b
 
 def divide(a,b):
     """


### PR DESCRIPTION
La fonction effectuait toujours l’opérande de gauche à la puissance (**) de l’opérande de droite au lieu de faire l’opérande de gauche multipliée (*) par l’opérande de droite. Par conséquent, au lieu de faire a ** b, la fonction a été modifié pour faire a * b.