### PR TITLE
Fix de la division

### DIFF
--- a/operators.py
+++ b/operators.py
@@ -56,4 +56,4 @@ def divide(a,b):
     Returns:
         float: Le résultat de la division
     """
-    return a // b
+    return a / b


### PR DESCRIPTION
La fonction effectuait toujours une division entière (//) de l’opérande de gauche par l’opérande de droite, ce qui tronque le reste. Il faut effectuer une division classique (/) afin d’obtenir le résultat avec les décimales. Par conséquent, au lieu de faire a //  b, la fonction a été modifié pour faire a / b.